### PR TITLE
Set device name via the AT+NAME<name>

### DIFF
--- a/src/bt.c
+++ b/src/bt.c
@@ -6,6 +6,8 @@
 
 #include <string.h>
 
+#include "defines.h"
+#include "settings.h"
 #include "esp_bt.h"
 #include "esp_bt_main.h"
 #include "esp_err.h"
@@ -14,12 +16,10 @@
 
 
 #define LOG_BT "BT"
-#define MAX_BTNAME_LEN 50
 
 esp_bd_addr_t localbtaddress;
 esp_bd_addr_t rmtbtaddress;
 
-char btname[MAX_BTNAME_LEN] = "Hello";
 
 void strtobtaddr(esp_bd_addr_t dest, char *src)
 {
@@ -91,7 +91,9 @@ void bt_disable()
 
 void btSetName(const char *name)
 {
-  strncpy(btname, name, sizeof(btname));
-  btname[sizeof(btname) - 1] = '\0';
-  ESP_LOGI(LOG_BT, "Setting BT Name %s", name);
+  strncpy(settings.name, name, sizeof(settings.name));
+  settings.name[sizeof(settings.name) - 1] = '\0';
+  saveSettings();
+  
+  ESP_LOGI(LOG_BT, "Setting BT Name %s", settings.name);
 }

--- a/src/bt.h
+++ b/src/bt.h
@@ -11,7 +11,6 @@
 
 extern esp_bd_addr_t rmtbtaddress;
 extern esp_bd_addr_t localbtaddress;
-extern char btname[];
 
 void strtobtaddr(esp_bd_addr_t dest, char *src);
 char *btaddrtostr(char dest[13], esp_bd_addr_t src);

--- a/src/bt_server.c
+++ b/src/bt_server.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "bt.h"
+#include "settings.h"
 #include "esp_bt.h"
 #include "esp_bt_defs.h"
 #include "esp_bt_main.h"
@@ -476,9 +477,20 @@ int btp_sendChannelData(uint8_t *data, int len)
 
 void btpInit(void)
 {
+  esp_err_t ret;
+
   ESP_LOGI(GATTS_TAG, "Starting Peripherial");
 
-  esp_err_t ret = esp_ble_gatts_register_callback(gatts_event_handler);
+  if (settings.name[0] != '\0') { 
+    ESP_LOGI(GATTS_TAG, "Setting device name [%s]",settings.name);
+    ret = esp_ble_gap_set_device_name(settings.name);
+    if (ret) {
+      ESP_LOGE(GATTS_TAG, "set device name error, error code = %x", ret);
+      return;
+    }
+  }
+  
+  ret = esp_ble_gatts_register_callback(gatts_event_handler);
   if (ret) {
     ESP_LOGE(GATTS_TAG, "gatts register error, error code = %x", ret);
     return;

--- a/src/settings.h
+++ b/src/settings.h
@@ -7,6 +7,7 @@ typedef struct {
   // uint8_t version // Todo the version info here, check on load it matches otherwise ignore
   char rmtbtaddr[13];
   role_t role;
+  char name[LEN_BLUETOOTH_NAME]; // Name of the device to broadcast instead of ESP32
 } settings_t;
 
 extern settings_t settings;


### PR DESCRIPTION
Persist the device name coming from the AT+NAME command from the TX.
Use that name to set up the BT device name.

Helps debug what is around you with a Bluetooth scanner. Otherwise, many "ESP32".